### PR TITLE
Fix the Row Selector for the Moves to Select

### DIFF
--- a/exporter.js
+++ b/exporter.js
@@ -14,8 +14,9 @@
 function exportMoves(format) {
     var moveIds = [];
     var wins = [];
-    $('a[data-id^="move-"] i.active').each(function() {
-        moveIds.push($(this).parent().attr('data-id').substring(5));
+
+    $(".row--selected").not(".odd").each(function(el) {
+        moveIds.push($(this).attr('data-moveid'));
     });
 
     if (confirm("This will export " + moveIds.length + " in format: " + format + ". Press Ok to export or Cancel to abort.")) {

--- a/exporter.js
+++ b/exporter.js
@@ -15,7 +15,7 @@ function exportMoves(format) {
     var moveIds = [];
     var wins = [];
 
-    $(".row--selected").not(".odd").each(function(el) {
+    $(".row--selected").not(".odd").each(function() {
         moveIds.push($(this).attr('data-moveid'));
     });
 


### PR DESCRIPTION
Looks like the current movescount webapp has been updated. These updates correctly grab the rows that are currently selected in the Movescount UI.